### PR TITLE
Fix feature getCurrentPosition

### DIFF
--- a/resources/views/latlong.blade.php
+++ b/resources/views/latlong.blade.php
@@ -8,10 +8,10 @@
 
         <div class="row">
             <div class="col-md-3">
-                <input id="{{$id['lat']}}" name="{{$name['lat']}}" class="form-control" value="{{ old($column['lat'], $value['lat']) }}" {!! $attributes !!} />
+                <input id="{{$id['lat']}}" name="{{$name['lat']}}" class="form-control" value="{{ old($column['lat'], $value['lat'] ?? null) }}" {!! $attributes !!} />
             </div>
             <div class="col-md-3">
-                <input id="{{$id['lng']}}" name="{{$name['lng']}}" class="form-control" value="{{ old($column['lng'], $value['lng']) }}" {!! $attributes !!} />
+                <input id="{{$id['lng']}}" name="{{$name['lng']}}" class="form-control" value="{{ old($column['lng'], $value['lng'] ?? null) }}" {!! $attributes !!} />
             </div>
 
             @if($provider != 'yandex')

--- a/src/Map/Google.php
+++ b/src/Map/Google.php
@@ -42,6 +42,7 @@ class Google extends AbstractMap
                       lng: position.coords.longitude
                     };
                     map.setCenter(pos);
+                    marker.setPosition(pos);
                     
                     lat.val(position.coords.latitude);
                     lng.val(position.coords.longitude);

--- a/src/Map/Google.php
+++ b/src/Map/Google.php
@@ -7,7 +7,7 @@ class Google extends AbstractMap
     /**
      * @var string
      */
-    protected $api = '//maps.googleapis.com/maps/api/js?v=3.exp&sensor=false&key=%s&libraries=places';
+    protected $api = '//maps.googleapis.com/maps/api/js?v=3.exp&key=%s&libraries=places';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
When `setAutoPosition` is defined, the blade file need to take value from variable `$value['lat']` and `$value['lng']`, but the function of set current position loaded after the blade, and the blade get null value from that variable. So this is how to avoid that problem and some fixes for google maps api too